### PR TITLE
clarify nonconservative terms

### DIFF
--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -119,8 +119,9 @@ quantities are denoted as $u$, \eg, mass, momentum, and energy for the compressi
 Euler equations of an ideal gas.
 The physical system is specified by the fluxes $f^j$ and the source term $s$.
 In addition, suitable initial and boundary conditions (ICs, BCs) are required.
-\trixi also handles non-conservative PDE terms as in the shallow water equations or magnetohydrodynamics equations
-with divergence cleaning.
+\trixi also handles non-conservative PDE terms as in the shallow water equations
+or magnetohydrodynamics equations with divergence cleaning, where source terms
+can depend on derivatives of~$u$.
 
 
 \subsection{Main features of Trixi.jl}


### PR DESCRIPTION
@simonbyrne Thank you very much for your review. I hope this PR clarifies the aspect mentioned in your first comment

> the paper states "Trixi.jl also handles non-conservative PDE terms as in the shallow water equations”. I was bit confused by this at first as Trixi uses the conservative formulation of the SWE (https://trixi-framework.github.io/Trixi.jl/stable/reference-trixi/#Trixi.ShallowWaterEquations2D) as opposed to the so-called "vector invariant" form of the SWE. This appears to be referring to a source term that involves a spatial gradient. Could this be expressed in a slightly different way?

You are right, the "nonconservative terms" refer to source terms that depend on derivatives of the solution. These terms cannot be expressed in a conservative form, i.e., as a divergence. 

Xref https://github.com/trixi-framework/paper-2021-juliacon/issues/22