### PR TITLE
convince whedon

### DIFF
--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -186,12 +186,12 @@ to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillatio
 \vspace{-0.7em}
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/jet_density}
-    \caption{{\fontsize{7}{10}\selectfont Density at time $t = 10^{-3}$.}}
+    \caption{Density at time $t = 10^{-3}$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/jet_mesh}
-    \caption{{\fontsize{7}{10}\selectfont Mesh at time $t = 10^{-3}$.}}
+    \caption{Mesh at time $t = 10^{-3}$.}
   \end{subfigure}%
   \caption{Numerical solutions of a supersonic jet with Mach number 2000 using
            sub-cell entropy-dissipative shock-capturing methods with sub-cell positivity-preserving
@@ -213,22 +213,22 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \begin{figure}[!ht]
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t2}
-    \caption{{\fontsize{7}{10}\selectfont Density at time $t = 2$.}}
+    \caption{Density at time $t = 2$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_mesh_t2}
-    \caption{{\fontsize{7}{10}\selectfont Mesh at time $t = 2$.}}
+    \caption{Mesh at time $t = 2$.}
   \end{subfigure}%
   \\
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t3}
-    \caption{{\fontsize{7}{10}\selectfont Density at time $t = 3$.}}
+    \caption{Density at time $t = 3$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_mesh_t3}
-    \caption{{\fontsize{7}{10}\selectfont Mesh at time $t = 3$.}}
+    \caption{Mesh at time $t = 3$.}
   \end{subfigure}%
   \caption{Numerical solutions of a Kelvin-Helmholtz instability using
            entropy-stable methods and adaptive mesh refinement for the
@@ -241,26 +241,26 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}
-    \caption{{\fontsize{7}{10}\selectfont Acoustic pressure at time $t = 0$.}}
+    \caption{Acoustic pressure, $t = 0$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_08}
-    \caption{{\fontsize{7}{10}\selectfont Acoustic pressure at time $t = 8$.}}
+    \caption{Acoustic pressure, $t = 8$.}
   \end{subfigure}%
   \\
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_16}
-    \caption{{\fontsize{7}{10}\selectfont Acoustic pressure at time $t = 16$.}}
+    \caption{Acoustic pressure, $t = 16$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_mesh}
-    \caption{{\fontsize{7}{10}\selectfont Unstructured quad mesh.}}
+    \caption{Unstructured quad mesh.}
     \label{fig:ginger_mesh}
   \end{subfigure}%
   \caption{Numerical solutions of pressure wave scattering for the acoustic
-                perturbation equations at three points in time as well as
+                perturbation equations at three points in time $t$ as well as
                 the unstructured, curvilinear quadrilateral mesh.}
   \label{fig:pressure_waves}
 \vspace{-0.7em}
@@ -580,7 +580,7 @@ better.
         \draw (axis cs:9,7.2e-7) -- (axis cs:8.5,5.2e-7);
       \end{axis}
     \end{tikzpicture}%
-    \caption{{\fontsize{7}{10}\selectfont Absolute run times.}}
+    \caption{Absolute run times.}
   \end{subfigure}%
   \\
   \begin{subfigure}{\linewidth}
@@ -614,7 +614,7 @@ better.
           \addlegendentry{Flux differencing}
       \end{axis}
     \end{tikzpicture}
-    \caption{{\fontsize{7}{10}\selectfont Run time relative to FLUXO.}}
+    \caption{Run time relative to FLUXO.}
   \end{subfigure}%
   \caption{Run time per right-hand side evaluation and degree of freedom for
            different DG discretizations of the 3D compressible Euler equations
@@ -660,7 +660,7 @@ better.
         \draw (axis cs:7,1.1e-6) -- (axis cs:7.5,6.5e-7);
       \end{axis}
     \end{tikzpicture}%
-    \caption{{\fontsize{7}{10}\selectfont Absolute run times.}}
+    \caption{Absolute run times.}
   \end{subfigure}%
   \\
   \begin{subfigure}{\linewidth}
@@ -693,7 +693,7 @@ better.
           \addlegendentry{EC flux}
       \end{axis}
     \end{tikzpicture}
-    \caption{{\fontsize{7}{10}\selectfont Run time relative to FLUXO.}}
+    \caption{Run time relative to FLUXO.}
   \end{subfigure}%
   \caption{Run time per right-hand side evaluation and degree of freedom for
            the flux differencing DG discretization of the 3D ideal MHD equations.

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -17,7 +17,7 @@
 % \sisetup{tight-spacing=true}
 
 % Use multiple images in a single environment
-\usepackage[font=footnotesize]{subcaption}
+\usepackage[font=scriptsize]{subcaption}
 
 % Allow external generation of images to speed up compilation
 \usepackage{tikz}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -261,6 +261,7 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
                 perturbation equations at three points in time as well as the unstructured,
                 curvilinear quadrilateral mesh.}
   \label{fig:pressure_waves}
+\vspace{-0.7em}
 \end{figure}
 
 
@@ -273,7 +274,7 @@ integration method. Currently, \trixi focuses on the spatial semidiscretization
 and uses mostly Runge-Kutta methods implemented in OrdinaryDiffEq.jl, which is part
 of DifferentialEquations.jl \cite{rackauckas2017differentialequations}.
 
-\begin{figure*}[htbp]
+\begin{figure*}[th]
 \centering
   \includegraphics[width=0.9\linewidth]{../figures/trixi_global_overview}
   \caption{Schematic overview of the basic components in \trixi and how they

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -241,17 +241,17 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}
-    \caption{Acoustic pressure at $t = 0$.}
+    \caption{Acoustic pressure, $t = 0$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_08}
-    \caption{Acoustic pressure at $t = 8$.}
+    \caption{Acoustic pressure, $t = 8$.}
   \end{subfigure}%
   \\
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_16}
-    \caption{Acoustic pressure at $t = 16$.}
+    \caption{Acoustic pressure, $t = 16$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -183,6 +183,7 @@ Figure~\ref{fig:jet} demonstrates sub-cell entropy-dissipative shock-capturing
 methods with sub-cell positivity-preserving limiters and adaptive mesh refinement applied
 to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillation}.
 \begin{figure}[!h]
+\captionsetup[subfigure]{font=footnotesize}
 \vspace{-0.7em}
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/jet_density}
@@ -211,6 +212,7 @@ curvilinear and unstructured domain. The 2D quadrilateral mesh used in the simul
 HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}}.
 
 \begin{figure}[!ht]
+\captionsetup[subfigure]{font=footnotesize}
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t2}
     \caption{Density at time $t = 2$.}
@@ -238,6 +240,7 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \end{figure}
 %
 \begin{figure}[!ht]
+\captionsetup[subfigure]{font=footnotesize}
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}
@@ -544,6 +547,7 @@ a relative comparison using FLUXO as reference in the bottom portion; smaller va
 better.
 
 \begin{figure}[!ht]
+\captionsetup[subfigure]{font=footnotesize}
 \centering
   \begin{subfigure}{\linewidth}
     \tikzsetnextfilename{runtime_euler_absolute}
@@ -623,6 +627,7 @@ better.
 \end{figure}
 
 \begin{figure}[!ht]
+\captionsetup[subfigure]{font=footnotesize}
 \centering
   \begin{subfigure}{\linewidth}
     \tikzsetnextfilename{runtime_mhd_absolute}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -183,7 +183,6 @@ Figure~\ref{fig:jet} demonstrates sub-cell entropy-dissipative shock-capturing
 methods with sub-cell positivity-preserving limiters and adaptive mesh refinement applied
 to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillation}.
 \begin{figure}[!h]
-\captionsetup[subfigure]{font=footnotesize}
 \vspace{-0.7em}
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/jet_density}
@@ -212,7 +211,6 @@ curvilinear and unstructured domain. The 2D quadrilateral mesh used in the simul
 HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}}.
 
 \begin{figure}[!ht]
-\captionsetup[subfigure]{font=footnotesize}
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t2}
     \caption{Density at time $t = 2$.}
@@ -240,7 +238,6 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \end{figure}
 %
 \begin{figure}[!ht]
-\captionsetup[subfigure]{font=footnotesize}
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}
@@ -547,7 +544,6 @@ a relative comparison using FLUXO as reference in the bottom portion; smaller va
 better.
 
 \begin{figure}[!ht]
-\captionsetup[subfigure]{font=footnotesize}
 \centering
   \begin{subfigure}{\linewidth}
     \tikzsetnextfilename{runtime_euler_absolute}
@@ -627,7 +623,6 @@ better.
 \end{figure}
 
 \begin{figure}[!ht]
-\captionsetup[subfigure]{font=footnotesize}
 \centering
   \begin{subfigure}{\linewidth}
     \tikzsetnextfilename{runtime_mhd_absolute}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -48,6 +48,8 @@
 
 \newcommand{\todo}[1]{{\color{red}#1}}
 
+\sloppy
+
 
 \begin{document}
 

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -203,6 +203,13 @@ to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillatio
 Figure~\ref{fig:kelvin_helmholtzs} demonstrates nonlinear stability
 obtained with entropy-stable methods and adaptive mesh refinement applied to a
 classical Kelvin-Helmholtz flow instability problem.
+
+Figure~\ref{fig:pressure_waves} shows the approximation
+of acoustic perturbation equations~\cite{ewert2003acoustic} wave scattering on a
+curvilinear and unstructured domain. The 2D quadrilateral mesh used in the simulation
+(Figure~\ref{fig:ginger_mesh}) was generated with
+HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}}.
+%
 \begin{figure}[!h]
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t2}
@@ -229,12 +236,7 @@ classical Kelvin-Helmholtz flow instability problem.
   \label{fig:kelvin_helmholtzs}
 \vspace{-0.7em}
 \end{figure}
-
-Figure~\ref{fig:pressure_waves} shows the approximation
-of acoustic perturbation equations~\cite{ewert2003acoustic} wave scattering on a
-curvilinear and unstructured domain. The 2D quadrilateral mesh used in the simulation
-(Figure~\ref{fig:ginger_mesh}) was generated with
-HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}}.
+%
 \begin{figure}[!h]
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -17,7 +17,7 @@
 % \sisetup{tight-spacing=true}
 
 % Use multiple images in a single environment
-\usepackage{subcaption}
+\usepackage[font=footnotesize]{subcaption}
 
 % Allow external generation of images to speed up compilation
 \usepackage{tikz}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -282,6 +282,7 @@ of DifferentialEquations.jl \cite{rackauckas2017differentialequations}.
   \caption{Schematic overview of the basic components in \trixi and how they
            interact.}
   \label{fig:trixi_global_overview}
+\vspace{-0.7em}
 \end{figure*}
 
 Figure~\ref{fig:trixi_global_overview} presents an overview of the basic

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -197,7 +197,7 @@ to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillatio
            sub-cell entropy-dissipative shock-capturing methods with sub-cell positivity-preserving
            limiters and adaptive mesh refinement for the compressible Euler equations.}
   \label{fig:jet}
-\vspace{-0.7em}
+\vspace{-1.4em}
 \end{figure}
 
 Figure~\ref{fig:kelvin_helmholtzs} demonstrates nonlinear stability
@@ -210,7 +210,7 @@ curvilinear and unstructured domain. The 2D quadrilateral mesh used in the simul
 (Figure~\ref{fig:ginger_mesh}) was generated with
 HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}}.
 
-\begin{figure}[!h]
+\begin{figure}[!ht]
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t2}
     \caption{Density at time $t = 2$.}
@@ -237,7 +237,7 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \vspace{-0.7em}
 \end{figure}
 %
-\begin{figure}[!h]
+\begin{figure}[!ht]
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -48,8 +48,6 @@
 
 \newcommand{\todo}[1]{{\color{red}#1}}
 
-\sloppy
-
 
 \begin{document}
 

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -209,7 +209,7 @@ of acoustic perturbation equations~\cite{ewert2003acoustic} wave scattering on a
 curvilinear and unstructured domain. The 2D quadrilateral mesh used in the simulation
 (Figure~\ref{fig:ginger_mesh}) was generated with
 HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}}.
-%
+
 \begin{figure}[!h]
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t2}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -19,6 +19,9 @@
 % Use multiple images in a single environment
 \usepackage{subcaption}
 
+% Option [H] for figure placement
+\usepackage{float}
+
 % Allow external generation of images to speed up compilation
 \usepackage{tikz}
 \usetikzlibrary{external}
@@ -182,7 +185,7 @@ repository for this article \cite{ranocha2021adaptiveRepro}.
 Figure~\ref{fig:jet} demonstrates sub-cell entropy-dissipative shock-capturing
 methods with sub-cell positivity-preserving limiters and adaptive mesh refinement applied
 to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillation}.
-\begin{figure}[!h]
+\begin{figure}[!ht]
 \vspace{-0.7em}
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/jet_density}
@@ -203,7 +206,7 @@ to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillatio
 Figure~\ref{fig:kelvin_helmholtzs} demonstrates nonlinear stability
 obtained with entropy-stable methods and adaptive mesh refinement applied to a
 classical Kelvin-Helmholtz flow instability problem.
-\begin{figure}[!h]
+\begin{figure}[!ht]
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t2}
     \caption{Density at time $t = 2$.}
@@ -235,7 +238,7 @@ of acoustic perturbation equations~\cite{ewert2003acoustic} wave scattering on a
 curvilinear and unstructured domain. The 2D quadrilateral mesh used in the simulation
 (Figure~\ref{fig:ginger_mesh}) was generated with
 HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}}.
-\begin{figure}[!h]
+\begin{figure}[H]
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -241,17 +241,17 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}
-    \caption{Acoustic pressure at time $t = 0$.}
+    \caption{Acoustic pressure at $t = 0$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_08}
-    \caption{Acoustic pressure at time $t = 8$.}
+    \caption{Acoustic pressure at $t = 8$.}
   \end{subfigure}%
   \\
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_16}
-    \caption{Acoustic pressure at time $t = 16$.}
+    \caption{Acoustic pressure at $t = 16$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
@@ -260,8 +260,8 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
     \label{fig:ginger_mesh}
   \end{subfigure}%
   \caption{Numerical solutions of pressure wave scattering for the acoustic
-                perturbation equations at three points in time as well as the unstructured,
-                curvilinear quadrilateral mesh.}
+                perturbation equations at three points in time $t$ as well as
+                the unstructured, curvilinear quadrilateral mesh.}
   \label{fig:pressure_waves}
 \vspace{-0.7em}
 \end{figure}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -19,9 +19,6 @@
 % Use multiple images in a single environment
 \usepackage{subcaption}
 
-% Option [H] for figure placement
-\usepackage{float}
-
 % Allow external generation of images to speed up compilation
 \usepackage{tikz}
 \usetikzlibrary{external}
@@ -185,7 +182,7 @@ repository for this article \cite{ranocha2021adaptiveRepro}.
 Figure~\ref{fig:jet} demonstrates sub-cell entropy-dissipative shock-capturing
 methods with sub-cell positivity-preserving limiters and adaptive mesh refinement applied
 to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillation}.
-\begin{figure}[!ht]
+\begin{figure}[!h]
 \vspace{-0.7em}
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/jet_density}
@@ -206,7 +203,7 @@ to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillatio
 Figure~\ref{fig:kelvin_helmholtzs} demonstrates nonlinear stability
 obtained with entropy-stable methods and adaptive mesh refinement applied to a
 classical Kelvin-Helmholtz flow instability problem.
-\begin{figure}[!ht]
+\begin{figure}[!h]
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t2}
     \caption{Density at time $t = 2$.}
@@ -238,7 +235,7 @@ of acoustic perturbation equations~\cite{ewert2003acoustic} wave scattering on a
 curvilinear and unstructured domain. The 2D quadrilateral mesh used in the simulation
 (Figure~\ref{fig:ginger_mesh}) was generated with
 HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}}.
-\begin{figure}[H]
+\begin{figure}[!h]
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -17,7 +17,8 @@
 % \sisetup{tight-spacing=true}
 
 % Use multiple images in a single environment
-\usepackage[font=scriptsize]{subcaption}
+\usepackage[font=scriptsize]{subcaption} % required for the old LaTeX installation of whedon
+% \usepackage{subcaption} % required for newer LaTeX installations
 
 % Allow external generation of images to speed up compilation
 \usepackage{tikz}
@@ -197,7 +198,7 @@ to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillatio
            sub-cell entropy-dissipative shock-capturing methods with sub-cell positivity-preserving
            limiters and adaptive mesh refinement for the compressible Euler equations.}
   \label{fig:jet}
-\vspace{-1.4em}
+\vspace{-0.7em}
 \end{figure}
 
 Figure~\ref{fig:kelvin_helmholtzs} demonstrates nonlinear stability
@@ -241,17 +242,17 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}
-    \caption{Acoustic pressure, $t = 0$.}
+    \caption{Acoustic pressure at time $t = 0$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_08}
-    \caption{Acoustic pressure, $t = 8$.}
+    \caption{Acoustic pressure at time $t = 8$.}
   \end{subfigure}%
   \\
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_16}
-    \caption{Acoustic pressure, $t = 16$.}
+    \caption{Acoustic pressure at time $t = 16$.}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
@@ -260,7 +261,7 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
     \label{fig:ginger_mesh}
   \end{subfigure}%
   \caption{Numerical solutions of pressure wave scattering for the acoustic
-                perturbation equations at three points in time $t$ as well as
+                perturbation equations at three points in time as well as
                 the unstructured, curvilinear quadrilateral mesh.}
   \label{fig:pressure_waves}
 \vspace{-0.7em}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -186,12 +186,12 @@ to an astrophysical supersonic jet with Mach number 2000 \cite{liu2021oscillatio
 \vspace{-0.7em}
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/jet_density}
-    \caption{Density at time $t = 10^{-3}$.}
+    \caption{{\fontsize{7}{10}\selectfont Density at time $t = 10^{-3}$.}}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/jet_mesh}
-    \caption{Mesh at time $t = 10^{-3}$.}
+    \caption{{\fontsize{7}{10}\selectfont Mesh at time $t = 10^{-3}$.}}
   \end{subfigure}%
   \caption{Numerical solutions of a supersonic jet with Mach number 2000 using
            sub-cell entropy-dissipative shock-capturing methods with sub-cell positivity-preserving
@@ -213,22 +213,22 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \begin{figure}[!ht]
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t2}
-    \caption{Density at time $t = 2$.}
+    \caption{{\fontsize{7}{10}\selectfont Density at time $t = 2$.}}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_mesh_t2}
-    \caption{Mesh at time $t = 2$.}
+    \caption{{\fontsize{7}{10}\selectfont Mesh at time $t = 2$.}}
   \end{subfigure}%
   \\
   \begin{subfigure}{0.52\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_density_t3}
-    \caption{Density at time $t = 3$.}
+    \caption{{\fontsize{7}{10}\selectfont Density at time $t = 3$.}}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/kelvin_helmholtz_mesh_t3}
-    \caption{Mesh at time $t = 3$.}
+    \caption{{\fontsize{7}{10}\selectfont Mesh at time $t = 3$.}}
   \end{subfigure}%
   \caption{Numerical solutions of a Kelvin-Helmholtz instability using
            entropy-stable methods and adaptive mesh refinement for the
@@ -241,26 +241,26 @@ HOHQMesh.jl\xspace\footnote{\url{https://github.com/trixi-framework/HOHQMesh.jl}
 \vspace{-0.7em}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_00}
-    \caption{Acoustic pressure, $t = 0$.}
+    \caption{{\fontsize{7}{10}\selectfont Acoustic pressure at time $t = 0$.}}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_08}
-    \caption{Acoustic pressure, $t = 8$.}
+    \caption{{\fontsize{7}{10}\selectfont Acoustic pressure at time $t = 8$.}}
   \end{subfigure}%
   \\
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_time_16}
-    \caption{Acoustic pressure, $t = 16$.}
+    \caption{{\fontsize{7}{10}\selectfont Acoustic pressure at time $t = 16$.}}
   \end{subfigure}%
   \hspace*{\fill}
   \begin{subfigure}{0.46\linewidth}
     \includegraphics[width=\textwidth]{../figures/ginger_mesh}
-    \caption{Unstructured quad mesh.}
+    \caption{{\fontsize{7}{10}\selectfont Unstructured quad mesh.}}
     \label{fig:ginger_mesh}
   \end{subfigure}%
   \caption{Numerical solutions of pressure wave scattering for the acoustic
-                perturbation equations at three points in time $t$ as well as
+                perturbation equations at three points in time as well as
                 the unstructured, curvilinear quadrilateral mesh.}
   \label{fig:pressure_waves}
 \vspace{-0.7em}
@@ -580,7 +580,7 @@ better.
         \draw (axis cs:9,7.2e-7) -- (axis cs:8.5,5.2e-7);
       \end{axis}
     \end{tikzpicture}%
-    \caption{Absolute run times.}
+    \caption{{\fontsize{7}{10}\selectfont Absolute run times.}}
   \end{subfigure}%
   \\
   \begin{subfigure}{\linewidth}
@@ -614,7 +614,7 @@ better.
           \addlegendentry{Flux differencing}
       \end{axis}
     \end{tikzpicture}
-    \caption{Run time relative to FLUXO.}
+    \caption{{\fontsize{7}{10}\selectfont Run time relative to FLUXO.}}
   \end{subfigure}%
   \caption{Run time per right-hand side evaluation and degree of freedom for
            different DG discretizations of the 3D compressible Euler equations
@@ -660,7 +660,7 @@ better.
         \draw (axis cs:7,1.1e-6) -- (axis cs:7.5,6.5e-7);
       \end{axis}
     \end{tikzpicture}%
-    \caption{Absolute run times.}
+    \caption{{\fontsize{7}{10}\selectfont Absolute run times.}}
   \end{subfigure}%
   \\
   \begin{subfigure}{\linewidth}
@@ -693,7 +693,7 @@ better.
           \addlegendentry{EC flux}
       \end{axis}
     \end{tikzpicture}
-    \caption{Run time relative to FLUXO.}
+    \caption{{\fontsize{7}{10}\selectfont Run time relative to FLUXO.}}
   \end{subfigure}%
   \caption{Run time per right-hand side evaluation and degree of freedom for
            the flux differencing DG discretization of the 3D ideal MHD equations.


### PR DESCRIPTION
The old LaTeX installation of whedon has a bug in the subcaption package/setup: The labels of subfigures are too big by default, even bigger than the main captions of figures. This fixes the problem and let's us keep the page limit.